### PR TITLE
Add disclaimers_consent field to EventAttendee schema

### DIFF
--- a/api/docs/eventdrive_v1.yml
+++ b/api/docs/eventdrive_v1.yml
@@ -2012,6 +2012,22 @@ components:
                         - moderator
                         - owner
                         - admin
+                disclaimers_consent:
+                    type: array
+                    readOnly: true
+                    items:
+                        type: object
+                        properties:
+                            disclaimer_id:
+                                type: integer
+                                format: int32
+                            titles:
+                                type: object
+                                properties:
+                                    en:
+                                        type: string
+                                additionalProperties:
+                                    type: string
         EventAttendeeRequestBody:
             type: object
             properties:


### PR DESCRIPTION
## Summary
- Add `disclaimers_consent` field to EventAttendee schema documentation
- Field is a read-only array containing attendee consent information for event disclaimers
- Each consent includes disclaimer_id and multilingual titles

## Changes
- Updated `EventAttendee` schema in `eventdrive_v1.yml`
- Added `disclaimers_consent` array property with proper structure

## Test plan
- [ ] Verify OpenAPI documentation renders correctly
- [ ] Confirm schema matches API response structure

🤖 Generated with [Claude Code](https://claude.com/claude-code)